### PR TITLE
fix postgres issue

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -47,7 +47,7 @@ function create(knex, platform) {
 
   return knex('webhooks')
   .insert({
-    created_on: moment().format('x'),
+    created_on: moment().toISOString(),
     platform: platform
   })
 }


### PR DESCRIPTION
postgres doens't work with unix timestamps, so using toISOString is required to use the module with postgres database